### PR TITLE
Add to instructions for importing other utilities

### DIFF
--- a/source/docs/adding-new-utilities.blade.md
+++ b/source/docs/adding-new-utilities.blade.md
@@ -66,6 +66,20 @@ If you're using a preprocessor like Less, Sass, or Stylus, consider keeping your
 @@import "custom-utilities";
 ```
 
+If you're using Post-CSS, you need to import Tailwinds from its own file to import other utilities. Otherwise you may get the error: `@import must precede all other statements`. For example:
+
+tailwind.css
+```
+@tailwind preflight;
+@tailwind utilities;
+```
+
+main.css
+```
+@import "tailwind";
+@import "custom-utilities";
+```
+
 ## Responsive Variants
 
 If you'd like to create responsive versions of your own utilities based on the breakpoints defined in your Tailwind config file, wrap your utilities in the `@responsive { ... }` directive:


### PR DESCRIPTION
Post-CSS users will need to structure their files this way, so I thought it worthy of being in the docs. It's come up twice in the last few days in Slack (with me being one of them). 

I added the error so that it may surface in searches.